### PR TITLE
Added space to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#Typechain
+# Typechain
 
 Learning Typescript by making a Blockchain with it


### PR DESCRIPTION
In order for github to read markdown syntaxs, you need space between the syntax special characters and the text you want to write. 